### PR TITLE
skip non searchable fields on mongoose query

### DIFF
--- a/packages/strapi-connector-mongoose/lib/buildQuery.js
+++ b/packages/strapi-connector-mongoose/lib/buildQuery.js
@@ -36,6 +36,9 @@ const buildSearchOr = (model, query) => {
   }
 
   const searchOr = Object.keys(model.attributes).reduce((acc, curr) => {
+    if (model.attributes[curr].searchable === false) {
+      return acc
+    }
     switch (model.attributes[curr].type) {
       case 'biginteger':
       case 'integer':


### PR DESCRIPTION
### What does it do?

skips `$or` filter in non searchable fields in mongo

### Why is it needed?

to enhance search performance

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/pull/9316
